### PR TITLE
Added password visibility toggle feature in login and signup page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "firebase": "^10.12.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.23.1",
         "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
@@ -15692,6 +15693,15 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "firebase": "^10.12.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.23.1",
     "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"

--- a/src/Pages/Login.js
+++ b/src/Pages/Login.js
@@ -5,10 +5,10 @@ import loader_icon from "../assets/icons/loader_icon.gif";
 import { useFirebase } from "../context/firebase";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { useNavigate, Link } from "react-router-dom";
+import { FaEye, FaEyeSlash } from 'react-icons/fa'; 
 import '../components/Navbar.css';
 
 const Login = () => {
-
   const firebase = useFirebase();
   const auth = getAuth();
   const navigate = useNavigate();
@@ -16,6 +16,7 @@ const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const [error, setError] = useState("");
   const [emailError, setEmailError] = useState("");
@@ -24,11 +25,11 @@ const Login = () => {
   useEffect(() => {
     onAuthStateChanged(auth, (user) => {
       if (user) {
-        navigate("/Home")
+        navigate("/Home");
       }
     });
     document.title = 'Login';
-  },[auth])
+  }, [auth]);
 
   const resetErrors = () => {
     setError("");
@@ -38,11 +39,11 @@ const Login = () => {
 
   const validateForm = () => {
     let isValid = true;
-    if (email == "") {
+    if (email === "") {
       setEmailError("(Required Field)");
       isValid = false;
     }
-    if (password == "") {
+    if (password === "") {
       setPasswordError("(Required Field)");
       isValid = false;
     }
@@ -52,28 +53,32 @@ const Login = () => {
   const handleSignIn = () => {
     resetErrors();
     let isValid = validateForm();
-    if (isValid == true) {
+    if (isValid) {
       setIsLoading(true);
-      setError("")
+      setError("");
       firebase.loginUserWithEmailAndPassword(email, password)
         .then(() => {
-          console.log("User login successfully!");
-          setEmail("")
-          setPassword("")
-          setError("")
+          console.log("User logged in successfully!");
+          setEmail("");
+          setPassword("");
+          setError("");
         })
         .catch(error => {
-          if (error.message == "Firebase: Error (auth/invalid-credential).")
-            setError("Incorrect email or password")
-          else if (error.message == "Firebase: Error (auth/invalid-email).")
-            setEmailError("(Invalid Email)")
+          if (error.message === "Firebase: Error (auth/invalid-credential).")
+            setError("Incorrect email or password");
+          else if (error.message === "Firebase: Error (auth/invalid-email).")
+            setEmailError("(Invalid Email)");
           else
-            setError("Can't Sign In, Unexpected error occured !!")
+            setError("Can't Sign In, Unexpected error occurred!");
         })
         .finally(() => {
           setIsLoading(false);
         });
     }
+  };
+
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible);
   };
 
   return (
@@ -99,20 +104,31 @@ const Login = () => {
           <label htmlFor="password" className="label-text">
             Password <span className="error-inline mxl-10">{passwordError}</span>
           </label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Password"
-            className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
-          />
+          <div className="input-wrapper">
+            <input
+              type={isPasswordVisible ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
+            />
+            <button
+              type="button"
+              className="password-toggle"
+              onClick={togglePasswordVisibility}
+            >
+              {isPasswordVisible ? <FaEyeSlash /> : <FaEye />}
+            </button>
+          </div>
           <div className={isLoading ? 'show-loader' : 'hide-div'}>
             <img src={loader_icon} alt="Loader Icon" />
           </div>
           <span className="error">{error}</span>
 
           <button className="btn" onClick={handleSignIn}>Login</button>
-          <span style={{marginTop: '20px', fontSize: '15px', display: 'block', textAlign: 'center'}}>Don't have an account <Link to="/SignUp" style={{color: '#f84464'}}>Sign Up</Link></span>
+          <span style={{ marginTop: '20px', fontSize: '15px', display: 'block', textAlign: 'center' }}>
+            Don't have an account <Link to="/SignUp" style={{ color: '#f84464' }}>Sign Up</Link>
+          </span>
         </div>
       </div>
     </>

--- a/src/Pages/SignUp.js
+++ b/src/Pages/SignUp.js
@@ -3,6 +3,7 @@ import { useFirebase } from "../context/firebase";
 import loader_icon from "../assets/icons/loader_icon.gif";
 import { Link, useNavigate } from 'react-router-dom'
 import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { FaEye, FaEyeSlash } from 'react-icons/fa'; 
 import './utils.css'
 import '../components/Navbar.css';
 
@@ -29,7 +30,10 @@ const SignUp = () => {
   const [theaterNameError, setTheaterNameError] = useState("");
   const [theaterAddressError, setTheaterAddressError] = useState("");
   const [passwordError, setPasswordError] = useState("");
-
+  const [isCreatePasswordVisible, setIsCreatePasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false);
+  
+  
   useEffect(() => {
     onAuthStateChanged(auth, (user) => {
       if (user) {
@@ -49,6 +53,13 @@ const SignUp = () => {
     setPasswordError("");
     setError("")
   }
+  const toggleCreatePasswordVisibility = () => {
+    setIsCreatePasswordVisible(!isCreatePasswordVisible);
+  };
+
+  const toggleConfirmPasswordVisibility = () => {
+    setIsConfirmPasswordVisible(!isConfirmPasswordVisible);
+  };
 
   const validateForm = () => {
     let isValid = true;
@@ -208,58 +219,52 @@ const SignUp = () => {
               onChange={(e) => setIsAdmin(e.target.value == 'true')} /><label htmlFor="admin-no" style={{marginLeft: '3px'}}>No</label>
           </div>
 
-          <div name='theater' className={isAdmin ? '' : 'hide-div'}>
-            <label className="label-text">
-              Theater Name 
-              <br/>
-              <span className="error-inline">{theaterNameError}</span>
-            </label>
-            <input
-              type="text"
-              value={theaterName}
-              onChange={(e) => setTheaterName(e.target.value)}
-              className={`input-field ${theaterNameError !== "" ? 'error-input-field' : ''}`}
-              placeholder="e.g. Rahulraj PVR"
-            />
-
-            <label className="label-text">
-              Theater Address
-              <br/>
-               <span className="error-inline">{theaterAddressError}</span>
-            </label>
-            <textarea
-              value={theaterAddress}
-              onChange={(e) => setTheaterAddress(e.target.value)}
-              className={`input-field ${theaterAddressError !== "" ? 'error-input-field' : ''}`}
-              placeholder="e.g. Robert Robertson, 1234 NW Bobcat Lane"
-            />
-          </div>
+          
 
           <label htmlFor="createPassword" className="label-text">
-            Create Password 
-            <br/>
-            <span className="error-inline">{passwordError}</span>
-          </label>
-          <input
-            type="password"
-            value={createPassword}
-            onChange={(e) => setCreatePassword(e.target.value)}
-            placeholder="Create Password"
-            className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
-          />
+    Create Password 
+    <br />
+    <span className="error-inline">{passwordError}</span>
+</label>
+<div className="input-wrapper create-password-wrapper">
+    <input
+        type={isCreatePasswordVisible ? "text" : "password"}
+        value={createPassword}
+        onChange={(e) => setCreatePassword(e.target.value)}
+        placeholder="Create Password"
+        className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
+    />
+    <button
+        type="button"
+        className="password-toggle"
+        onClick={toggleCreatePasswordVisibility} // Call the correct function
+    >
+        {isCreatePasswordVisible ? <FaEyeSlash /> : <FaEye />}
+    </button>
+</div>
 
-          <label htmlFor="confirmPassword" className="label-text">
-            Confirm Password
-            <br/>
-             <span className="error-inline">{passwordError}</span>
-          </label>
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            placeholder="Confirm Password"
-            className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
-          />
+<label htmlFor="confirmPassword" className="label-text">
+    Confirm Password
+    <br />
+    <span className="error-inline">{passwordError}</span>
+</label>
+<div className="input-wrapper confirm-password-wrapper">
+    <input
+        type={isConfirmPasswordVisible ? "text" : "password"}
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        placeholder="Confirm Password"
+        className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
+    />
+    <button
+        type="button"
+        className="password-toggle"
+        onClick={toggleConfirmPasswordVisibility} // Call the correct function
+    >
+        {isConfirmPasswordVisible ? <FaEyeSlash /> : <FaEye />}
+    </button>
+</div>
+
 
           <div className={isLoading ? 'show-loader' : 'hide-div'}>
             <img src={loader_icon} alt="Loader Icon" />

--- a/src/Pages/SignUp.js
+++ b/src/Pages/SignUp.js
@@ -63,12 +63,12 @@ const SignUp = () => {
 
   const validateForm = () => {
     let isValid = true;
-    if (name == "") {
+    if (name === "") {
       setNameError("(Required Field)");
       isValid = false;
     }
 
-    if (email == "") {
+    if (email === "") {
       setEmailError("(Required Field)");
       isValid = false;
     }
@@ -77,18 +77,18 @@ const SignUp = () => {
       isValid = false;
     }
 
-    if (isAdmin == true) {
-      if (theaterName == "") {
+    if (isAdmin === true) {
+      if (theaterName === "") {
         setTheaterNameError("(Invalid Theater name)");
         isValid = false;
       }
-      if (theaterAddress == "") {
+      if (theaterAddress === "") {
         setTheaterAddressError("(Invalid Theater address)");
         isValid = false;
       }
     }
 
-    if (createPassword != confirmPassword) {
+    if (createPassword !== confirmPassword) {
       setPasswordError("(Passwords are not matching)")
       isValid = false;
     } else {
@@ -107,13 +107,13 @@ const SignUp = () => {
   const handleSignUp = () => {
     resetErrors();
     let isValid = validateForm()
-    if (isValid == true) {
+    if (isValid === true) {
       setIsLoading(true);
       setError("")
       firebase.signupUserWithEmailAndPassword(email, createPassword)
         .then((userCredential) => {
           console.log("User signed up successfully!");
-          if (isAdmin == true) {
+          if (isAdmin === true) {
             firebase.addUser(userCredential.user.uid, { name, email, phone, isAdmin, theaterName, theaterAddress, wallet:2000 })
               .then(() => {
                 console.log("User data successfully stored in Firebase");
@@ -148,9 +148,9 @@ const SignUp = () => {
         })
         .catch(error => {
           console.error("Error signing up:", error.message);
-          if (error.message == "Firebase: Error (auth/email-already-in-use).")
+          if (error.message === "Firebase: Error (auth/email-already-in-use).")
             setError("Can't Sign Up, Email address already in use");
-          else if (error.message == "Firebase: Error (auth/invalid-email).")
+          else if (error.message === "Firebase: Error (auth/invalid-email).")
             setError("Can't Sign Up, Invalid email");
           else
             setError("Can't Sign Up, Unexpected error occured !!");

--- a/src/Pages/SignUp.js
+++ b/src/Pages/SignUp.js
@@ -219,51 +219,77 @@ const SignUp = () => {
               onChange={(e) => setIsAdmin(e.target.value == 'true')} /><label htmlFor="admin-no" style={{marginLeft: '3px'}}>No</label>
           </div>
 
+          <div name='theater' className={isAdmin ? '' : 'hide-div'}>
+            <label className="label-text">
+              Theater Name 
+              <br/>
+              <span className="error-inline">{theaterNameError}</span>
+            </label>
+            <input
+              type="text"
+              value={theaterName}
+              onChange={(e) => setTheaterName(e.target.value)}
+              className={`input-field ${theaterNameError !== "" ? 'error-input-field' : ''}`}
+              placeholder="e.g. Rahulraj PVR"
+            />
+
+            <label className="label-text">
+              Theater Address
+              <br/>
+               <span className="error-inline">{theaterAddressError}</span>
+            </label>
+            <textarea
+              value={theaterAddress}
+              onChange={(e) => setTheaterAddress(e.target.value)}
+              className={`input-field ${theaterAddressError !== "" ? 'error-input-field' : ''}`}
+              placeholder="e.g. Robert Robertson, 1234 NW Bobcat Lane"
+            />
+          </div>
           
 
           <label htmlFor="createPassword" className="label-text">
-    Create Password 
-    <br />
-    <span className="error-inline">{passwordError}</span>
-</label>
-<div className="input-wrapper create-password-wrapper">
-    <input
-        type={isCreatePasswordVisible ? "text" : "password"}
-        value={createPassword}
-        onChange={(e) => setCreatePassword(e.target.value)}
-        placeholder="Create Password"
-        className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
-    />
-    <button
-        type="button"
-        className="password-toggle"
-        onClick={toggleCreatePasswordVisibility} // Call the correct function
-    >
-        {isCreatePasswordVisible ? <FaEyeSlash /> : <FaEye />}
-    </button>
-</div>
+              Create Password 
+              <br />
+              <span className="error-inline">{passwordError}</span>
+          </label>
+          <div className="input-wrapper create-password-wrapper">
+              <input
+                  type={isCreatePasswordVisible ? "text" : "password"}
+                  value={createPassword}
+                  onChange={(e) => setCreatePassword(e.target.value)}
+                  placeholder="Create Password"
+                  className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
+              />
+              <button
+                  type="button"
+                  className="password-toggle"
+                  onClick={toggleCreatePasswordVisibility} 
+              >
+                  {isCreatePasswordVisible ? <FaEyeSlash /> : <FaEye />}
+              </button>
+          </div>
 
-<label htmlFor="confirmPassword" className="label-text">
-    Confirm Password
-    <br />
-    <span className="error-inline">{passwordError}</span>
-</label>
-<div className="input-wrapper confirm-password-wrapper">
-    <input
-        type={isConfirmPasswordVisible ? "text" : "password"}
-        value={confirmPassword}
-        onChange={(e) => setConfirmPassword(e.target.value)}
-        placeholder="Confirm Password"
-        className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
-    />
-    <button
-        type="button"
-        className="password-toggle"
-        onClick={toggleConfirmPasswordVisibility} // Call the correct function
-    >
-        {isConfirmPasswordVisible ? <FaEyeSlash /> : <FaEye />}
-    </button>
-</div>
+          <label htmlFor="confirmPassword" className="label-text">
+              Confirm Password
+              <br />
+              <span className="error-inline">{passwordError}</span>
+          </label>
+          <div className="input-wrapper confirm-password-wrapper">
+              <input
+                  type={isConfirmPasswordVisible ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="Confirm Password"
+                  className={`input-field ${passwordError !== "" ? 'error-input-field' : ''}`}
+              />
+              <button
+                  type="button"
+                  className="password-toggle"
+                  onClick={toggleConfirmPasswordVisibility} // Call the correct function
+              >
+                  {isConfirmPasswordVisible ? <FaEyeSlash /> : <FaEye />}
+              </button>
+          </div>
 
 
           <div className={isLoading ? 'show-loader' : 'hide-div'}>

--- a/src/Pages/utils.css
+++ b/src/Pages/utils.css
@@ -171,3 +171,39 @@ input[type="file"]::file-selector-button {
 .justify-between {
     justify-content: space-between;
 }
+
+.input-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.input-field {
+    width: 100%;
+    padding-right: 40px;
+}
+
+.password-toggle {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    padding-bottom: 10px;
+    font-size: 23px;
+    color: rgb(33, 33, 33);
+}
+
+
+.create-password-wrapper .input-field {
+    border: 1px solid #ccc;
+    padding-right: 40px;
+}
+
+.confirm-password-wrapper .input-field {
+    border: 1px solid #ccc;
+    padding-right: 40px;
+}
+


### PR DESCRIPTION
**Description**: This pull request introduces a password visibility toggle feature for the user authentication forms, specifically for the "Create Password" and "Confirm Password" fields.

**Changes Made:**

- Added two state variables: isCreatePasswordVisible and isConfirmPasswordVisible to manage the visibility of the respective password fields.
- Created toggle functions (toggleCreatePasswordVisibility and toggleConfirmPasswordVisibility) to switch between showing and hiding passwords.
- Updated the JSX for both password input fields to include the toggle button with appropriate icons.
- Added specific CSS styles to ensure the password fields are distinct and visually appealing.
- **Installed **React Icons****: Added the react-icons library to use eye icons for password visibility toggles. Installation command:

![Screenshot 2024-10-02 121852](https://github.com/user-attachments/assets/28b96f87-660c-4423-88a9-0fed27e3deac)
![Screenshot 2024-10-02 120737](https://github.com/user-attachments/assets/d0a2a4d4-1180-41d5-b1a4-1460080d8106)
